### PR TITLE
Logic fix in AdminRowActionsMixin.get_row_actions

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -92,10 +92,7 @@ class AdminRowActionsMixin(admin.ModelAdmin):
     ##################
 
     def get_row_actions(self, obj):
-        if getattr(self, 'rowactions', False):
-            return []
-        else:
-            return self.rowactions
+        return getattr(self, 'rowactions', False) or []
 
     # Default to using row actions for object actions
     # Aside from the 'Edit' action of course


### PR DESCRIPTION
Old code block have problem in logic:
1. If AdminModel object has attribute `rowactions` it returns empty list.
2. If object has not attribute `rowactions` it returned current value of attribute. But attribute has no value (really it has default AdminRowActionsMixin.rowactions value), we just check it. LOL

Fixed.
