### PR TITLE
Fixed return url after calling action on object

### DIFF
--- a/django_admin_row_actions/views.py
+++ b/django_admin_row_actions/views.py
@@ -3,17 +3,17 @@ from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.views.generic import View
 from django.views.generic.detail import SingleObjectMixin
+from django.core.urlresolvers import reverse
 
 
 class ModelToolsView(SingleObjectMixin, View):
-    
     """A special view that run the tool's callable"""
 
     def get(self, request, **kwargs):
-        
+
         # SingleOjectMixin's `get_object`. Works because the view
         # is instantiated with `model` and the urlpattern has `pk`.
-        
+
         obj = self.get_object()
         try:
             model_admin = admin.site._registry[obj.__class__]
@@ -22,7 +22,10 @@ class ModelToolsView(SingleObjectMixin, View):
             raise Http404
         if isinstance(ret, HttpResponse):
             return ret
-        back = request.path.rsplit('/', 3)[0] + '/'
+
+        meta = model_admin.model._meta
+        back = reverse("admin:%s_%s_changelist" % (meta.app_label, meta.model_name))
+
         return HttpResponseRedirect(back)
 
     # Allow POST


### PR DESCRIPTION
Return url now doesn't depends on urls patterns. It builds from model name to admin changelist view.
