### PR TITLE
Support Python 3.0+

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -38,7 +38,7 @@ class AdminRowActionsMixin(object):
         url_prefix = '{}/'.format(obj.pk if includePk else '')
         
         for tool in row_actions:
-            if isinstance(tool, basestring):  # Just a str naming a callable
+            if isinstance(tool, str):  # Just a str naming a callable
                 tool_dict = to_dict(tool)
                 items.append({
                     'label': tool_dict['label'],

--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -1,5 +1,7 @@
 from django.conf.urls import patterns
 
+from six import string_types
+
 from .components import Dropdown
 from .views import ModelToolsView
 
@@ -38,7 +40,7 @@ class AdminRowActionsMixin(object):
         url_prefix = '{}/'.format(obj.pk if includePk else '')
         
         for tool in row_actions:
-            if isinstance(tool, basestring):  # Just a str naming a callable
+            if isinstance(tool, string_types):  # Just a str naming a callable
                 tool_dict = to_dict(tool)
                 items.append({
                     'label': tool_dict['label'],
@@ -114,10 +116,10 @@ class AdminRowActionsMixin(object):
     
             for row_action in row_actions:
                 # Object actions only supports strings as action indentifiers
-                if isinstance(row_action, basestring):
+                if isinstance(row_action, string_types):
                     change_actions.append(row_action)
                 elif isinstance(row_action, dict):
-                    if isinstance(row_action['action'], basestring):
+                    if isinstance(row_action['action'], string_types):
                         change_actions.append(row_action['action'])
                     elif isinstance(row_action['action'], tuple):
                         change_actions.append(str(row_action['action'][1]))

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ setup(
     author='Andy Baker',
     author_email='andy@andybak.net',
     packages=find_packages(),
+    install_requires=[
+        'six',
+    ],
     package_data={
         'django_admin_row_actions': [
             'static/css/*.css',


### PR DESCRIPTION
From the [Python 3.0 What's New Documentation](https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit):

> The builtin `basestring` abstract type was removed. Use `str` instead. The `str` and `bytes` types don’t have functionality enough in common to warrant a shared base class. The `2to3` tool (see below) replaces every occurrence of `basestring` with `str`.
