### PR TITLE
Limit use of django.conf.urls.patterns

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -4,7 +4,7 @@ def patterns(prefix, *args):
         from django.conf.urls import patterns as django_patterns
         return django_patterns(prefix, *args)
     else:
-        return list(*args)
+        return list(args)
 
 from six import string_types
 

--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -1,4 +1,10 @@
-from django.conf.urls import patterns
+from django import VERSION
+def patterns(prefix, *args):
+    if prefix != '' or VERSION < (1, 9):
+        from django.conf.urls import patterns as django_patterns
+        return django_patterns(prefix, *args)
+    else:
+        return list(*args)
 
 from six import string_types
 


### PR DESCRIPTION
It's removed entirely in Django >= 1.10 and raises warnings on Django 1.9.
