### PR TITLE
Update (and fix) admin.py for Django 1.9+

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -1,9 +1,21 @@
-from django.conf.urls import patterns
+from django import VERSION
+from django.conf.urls import url
 
 from six import string_types
 
 from .components import Dropdown
 from .views import ModelToolsView
+
+
+def patterns(prefix, *args):
+    if VERSION < (1, 9):
+        from django.conf.urls import patterns as django_patterns
+        return django_patterns(prefix, *args)
+    elif prefix != '':
+        raise Exception("You need to update your URLConf to be a list of URL "
+                        "objects")
+    else:
+        return list(args)
 
 
 class AdminRowActionsMixin(object):
@@ -77,7 +89,7 @@ class AdminRowActionsMixin(object):
         
         my_urls = patterns(
             '',
-            (r'^(?P<pk>\d+)/rowactions/(?P<tool>\w+)/$',
+            url(r'^(?P<pk>\d+)/rowactions/(?P<tool>\w+)/$',
                 self.admin_site.admin_view(ModelToolsView.as_view(model=self.model))
             )
         )


### PR DESCRIPTION
For Django 1.9+, URL patterns need to be a vanilla Python list of URL objects, so I created a `patterns()` function that delegated to the normal Django `patterns()` function and returned a list of `url()`s for Django 1.9+.

Also, `get_tool_urls()` should create URL objects with `url()`. The fact that it didn't was a pre-existing bug that is now fixed.

This supercedes #5.
