### PR TITLE
Add method parameter to allow 'POST' actions

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -20,7 +20,7 @@ def patterns(prefix, *args):
 
 
 class AdminRowActionsMixin(object):
-    
+
     """ModelAdmin mixin to add row actions just like adding admin actions"""
 
     rowactions = []
@@ -32,64 +32,67 @@ class AdminRowActionsMixin(object):
         media.add_js(['js/jquery.dropdown.min.js'])
         media.add_css({'all': ['css/jquery.dropdown.min.css']})
         return media
-        
+
     def get_list_display(self, request):
+        self._request = request
         list_display = super(AdminRowActionsMixin, self).get_list_display(request)
         if '_row_actions' not in list_display:
             list_display += ('_row_actions',)
         return list_display
-    
+
     def get_actions_list(self, obj, includePk=True):
-        
+
         def to_dict(tool_name):
             return dict(
                 name=tool_name,
                 label=getattr(tool, 'label', tool_name).replace('_', ' ').title(),
             )
-        
+
         items = []
-        
+
         row_actions = self.get_row_actions(obj)
         url_prefix = '{}/'.format(obj.pk if includePk else '')
-        
+
         for tool in row_actions:
             if isinstance(tool, string_types):  # Just a str naming a callable
                 tool_dict = to_dict(tool)
                 items.append({
                     'label': tool_dict['label'],
                     'url': '{}rowactions/{}/'.format(url_prefix, tool),
+                    'method': tool_dict.get('POST', 'GET')
                 })
-                
+
             elif isinstance(tool, dict):  # A parameter dict
                 tool['enabled'] = tool.get('enabled', True)
-                if 'action' in tool:  # If 'action' is specified then use our generic url in preference to 'url' value
+                if 'action' in tool:      # If 'action' is specified then use our generic url in preference to 'url' value
                     if isinstance(tool['action'], tuple):
                         self._named_row_actions[tool['action'][0]] = tool['action'][1]
                         tool['url'] = '{}rowactions/{}/'.format(url_prefix, tool['action'][0])
                     else:
                         tool['url'] = '{}rowactions/{}/'.format(url_prefix, tool['action'])
                 items.append(tool)
-        
+
         return items
-    
+
     def _row_actions(self, obj):
-        
+
         items = self.get_actions_list(obj)
         if items:
             html = Dropdown(
                 label=_("Actions"),
                 items=items,
+                request=getattr(self, '_request')
             ).render()
 
             return html
         return ''
     _row_actions.short_description = ''
     _row_actions.allow_tags = True
-    
+
     def get_tool_urls(self):
-        
+
         """Gets the url patterns that route each tool to a special view"""
-        
+
         my_urls = patterns(
             '',
             url(r'^(?P<pk>\d+)/rowactions/(?P<tool>\w+)/$',
@@ -97,38 +100,38 @@ class AdminRowActionsMixin(object):
             )
         )
         return my_urls
-    
+
     ###################################
     # EXISTING ADMIN METHODS MODIFIED #
     ###################################
-    
+
     def get_urls(self):
-        
+
         """Prepends `get_urls` with our own patterns"""
-        
+
         urls = super(AdminRowActionsMixin, self).get_urls()
         return self.get_tool_urls() + urls
-    
+
     ##################
     # CUSTOM METHODS #
     ##################
-    
+
     def get_row_actions(self, obj):
         return getattr(self, 'rowactions', False) or []
-    
+
     def get_change_actions(self, request, object_id, form_url):
-    
+
         # If we're also using django_object_actions
         # then try to reuse row actions as object actions
-    
+
         change_actions = super(AdminRowActionsMixin, self).get_change_actions(request, object_id, form_url)
-        
+
         # Make this reuse opt-in
         if getattr(self, 'reuse_row_actions_as_object_actions', False):
 
             obj = self.model.objects.get(pk=object_id)
             row_actions = self.get_actions_list(obj, False) if obj else []
-    
+
             for row_action in row_actions:
                 # Object actions only supports strings as action indentifiers
                 if isinstance(row_action, string_types):

--- a/django_admin_row_actions/components.py
+++ b/django_admin_row_actions/components.py
@@ -3,16 +3,13 @@ from django.template.loader import render_to_string
 
 
 class BaseComponent(object):
-    
+
     template = None
     instances = []
 
     def __init__(self, **kwargs):
-        
-        # Add ourselves to the class's list of instances
-        # so we can generate a unique id number for the html
-        
         self.__class__.instances.append(weakref.proxy(self))
+        self.request = kwargs.pop('request')
         self.context = kwargs
         self.context['dom_id'] = self.get_unique_id()
 
@@ -24,6 +21,7 @@ class BaseComponent(object):
         return render_to_string(
             self.template,
             self.context,
+            request=self.request
         )
 
     def __unicode__(self):

--- a/django_admin_row_actions/templates/django_admin_row_actions/dropdown.html
+++ b/django_admin_row_actions/templates/django_admin_row_actions/dropdown.html
@@ -8,7 +8,16 @@
             {% endif %}
             <li>
                 {% if item.enabled %}
-                    <a class="{{ item.classes }}" href="{{ item.url }}" title="{{ item.tooltip }}">{{ item.label }}</a>
+                    {% if item.method == 'POST' %}
+                    <form method="post" action="{{ item.url }}">
+                        {% csrf_token %}
+                        <input class="{{ item.classes }}" type="submit" title="{{ item.tooltip }}" value="{{ item.label }}" />
+                    </form>
+                    {% else %}
+
+                    <a class="{{ item.classes }}" href="{{ item.url }}" title="{{ item.tooltip }}">{{ item.label }}
+                    </a>
+                    {% endif %}
                 {% else %}
                     <span class="{{ item.classes }} jq-disabled" title="{{ item.tooltip }}">{{ item.label }}</span>
                 {% endif %}


### PR DESCRIPTION
This patch add a new key 'method' to the action dict.
If it's `'POST'`, a form with a submit button is rendered,
instead of a link.
