### PR TITLE
Add support for UUID in urls and custom AdminSite's

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -95,7 +95,7 @@ class AdminRowActionsMixin(object):
 
         my_urls = patterns(
             '',
-            url(r'^(?P<pk>\d+)/rowactions/(?P<tool>\w+)/$',
+            url(r'^(?P<pk>[0-9a-f-]+)/rowactions/(?P<tool>\w+)/$',
                 self.admin_site.admin_view(ModelToolsView.as_view(model=self.model))
             )
         )

--- a/django_admin_row_actions/utils.py
+++ b/django_admin_row_actions/utils.py
@@ -1,5 +1,6 @@
 from functools import wraps
 from django.db.models.query import QuerySet
+from django.contrib.admin.sites import all_sites
 
 
 class QuerySetIsh(QuerySet):
@@ -39,3 +40,15 @@ def takes_instance_or_queryset(func):
             queryset = QuerySetIsh(queryset)
         return func(self, request, queryset)
     return decorated_function
+
+
+def get_django_model_admin(model):
+    """Search Django ModelAdmin for passed model.
+
+    Returns instance if found, otherwise None.
+    """
+    for admin_site in all_sites:
+        registry = admin_site._registry
+        if model in registry:
+            return registry[model]
+    return None

--- a/django_admin_row_actions/utils.py
+++ b/django_admin_row_actions/utils.py
@@ -1,6 +1,6 @@
 from functools import wraps
-from django.db.models.query import QuerySet
 from django.contrib.admin.sites import all_sites
+from django.db.models.query import QuerySet
 
 
 class QuerySetIsh(QuerySet):

--- a/django_admin_row_actions/views.py
+++ b/django_admin_row_actions/views.py
@@ -18,7 +18,7 @@ class ModelToolsView(SingleObjectMixin, View):
         obj = self.get_object()
         model_admin = get_django_model_admin(obj.__class__)
         if not model_admin:
-            raise Http404('Can not find ModelAdmin for %r', obj.__class__)
+            raise Http404('Can not find ModelAdmin for {}'.format(obj.__class__))
         
         # Look up the action in the following order:
         # 1. in the named_row_actions dict (for lambdas etc)

--- a/django_admin_row_actions/views.py
+++ b/django_admin_row_actions/views.py
@@ -1,8 +1,9 @@
-from django.contrib import admin
 from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.views.generic import View
 from django.views.generic.detail import SingleObjectMixin
+
+from .utils import get_django_model_admin
 
 
 class ModelToolsView(SingleObjectMixin, View):
@@ -15,7 +16,9 @@ class ModelToolsView(SingleObjectMixin, View):
         # is instantiated with `model` and the urlpattern has `pk`.
         
         obj = self.get_object()
-        model_admin = admin.site._registry[obj.__class__]
+        model_admin = get_django_model_admin(obj.__class__)
+        if not model_admin:
+            raise Http404('Can not find ModelAdmin for %r', obj.__class__)
         
         # Look up the action in the following order:
         # 1. in the named_row_actions dict (for lambdas etc)


### PR DESCRIPTION
1. Django has the option to have UUID [1] as the primary key. Here I am extending regexp pattern to catch UUID string as well. Backward compatibility is preserved because `\d` is the same as `[0-9]`.
2. Using `action` option for custom admin sites [2] causes currently KeyError, because of looking up for models registered only to default AdminSite instance. Here I am providing a way to look for all AdminSites by iterating over Django `all_sites`. Also, 404 is raised to ease the pain of the debugging if ModelAdmin still cannot be found.


[1] https://docs.djangoproject.com/en/stable/ref/models/fields/#uuidfield
[2] https://docs.djangoproject.com/en/stable/ref/contrib/admin/#customizing-the-adminsite-class