### PR TITLE
Document 'divided' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Installation
                 'url': reverse('convert_stuff', args=[obj.id]),
                 'tooltip': 'Convert stuff',
             }, {
+                'divided': True,
                 'label': 'Cancel',
                 'action': 'mark_cancelled',
             },
@@ -73,6 +74,8 @@ The first three menu items are simple links to a url you provide by whatever mea
 The final one defines 'action' instead of 'url'. This should be the name of a callable on your `ModelAdmin` or `Model` class (similar to [ModelAdmin.list_display](https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display)).
 
 You can add mouseover tooltips to each individual actions with the 'tooltip' dictionary key, and enable/disable individual actions for each individual object with the 'enabled'.
+
+Special option 'divided' can be passed to any item to display horizontal rule above it.
 
 
 Credits


### PR DESCRIPTION
By looking at the template source code, I find out that we have forgotten option to create a horizontal rule between options. Here I ~repaired it and~ documented it. ~I also allowed myself to rename it to "divider" as this name seems to better explain the role. On the other hand, I can at this point break the backward compatibility. What do you think?~

![selection_113](https://user-images.githubusercontent.com/1640089/31997101-12b384b4-b98b-11e7-8327-11d141570cc9.png)
