### PR TITLE
Improve media method

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -30,18 +30,10 @@ class AdminRowActionsMixin(object):
 
     @property
     def media(self):
-        css = super(AdminRowActionsMixin, self).media._css
-        css['all'] = css.get('all', [])
-        css['all'].extend(["css/jquery.dropdown.min.css"])
-
-        js = super(AdminRowActionsMixin, self).media._js
-        js.extend(["js/jquery.dropdown.min.js",])
-
-        media = forms.Media(
-            css=css, js=js
+        return super(AdminRowActionsMixin, self).media + forms.Media(
+            css={'all': ["css/jquery.dropdown.min.css"]},
+            js=["js/jquery.dropdown.min.js"],
         )
-
-        return media
 
     def get_list_display(self, request):
         self._request = request


### PR DESCRIPTION
Avoid mutating the contents of the lists from the instance returned from `super()`, and instead use addition, [the recommended method of combining Media classes](https://docs.djangoproject.com/en/2.2/topics/forms/media/#combining-media-objects).