### PR TITLE
fix Django > 4.0: django.conf.urls.url was removed

### DIFF
--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -2,7 +2,7 @@ from django import VERSION
 from django import forms
 from django.urls import re_path
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from six import string_types
 

--- a/django_admin_row_actions/admin.py
+++ b/django_admin_row_actions/admin.py
@@ -1,6 +1,6 @@
 from django import VERSION
 from django import forms
-from django.conf.urls import url
+from django.urls import re_path
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
@@ -109,7 +109,7 @@ class AdminRowActionsMixin(object):
 
         my_urls = patterns(
             '',
-            url(r'^(?P<pk>[0-9a-f-]+)/rowactions/(?P<tool>\w+)/$',
+            re_path(r'^(?P<pk>[0-9a-f-]+)/rowactions/(?P<tool>\w+)/$',
                 self.admin_site.admin_view(ModelToolsView.as_view(model=self.model))
             )
         )


### PR DESCRIPTION
This commit fixes reported issue: https://github.com/DjangoAdminHackers/django-admin-row-actions/issues/26

The deprecated and now removed function `django.conf.urls.url` was replaced with `django.conf.urls.url`